### PR TITLE
Fail with clear error when no source found in supermarket

### DIFF
--- a/lib/knife/changelog/changelog.rb
+++ b/lib/knife/changelog/changelog.rb
@@ -133,6 +133,7 @@ class KnifeChangelog
 
     def handle_source(name, dep)
       url = get_from_supermarket_sources(name)
+      raise "No source found in supermarket for cookbook '#{name}'" unless url
       Chef::Log.debug("Using #{url} as source url")
       case url.strip
       when /(gitlab.*|github).com\/(.*)(.git)?/

--- a/lib/knife/changelog/version.rb
+++ b/lib/knife/changelog/version.rb
@@ -1,5 +1,5 @@
 module Knife
   module Changelog
-    VERSION = "0.5.11"
+    VERSION = "0.5.12"
   end
 end


### PR DESCRIPTION
Former implementation was just raising NCE and no proper message to find out
which cookbook was involved.

**Cc.** @aboten