### PR TITLE
Use first available supermarket source

### DIFF
--- a/lib/knife/changelog/changelog.rb
+++ b/lib/knife/changelog/changelog.rb
@@ -117,9 +117,8 @@ class KnifeChangelog
       end
         .compact
         .map { |json| JSON.parse(json) }
-        .sort_by { |ck| Gem::Version.new(ck['latest_version'].split('/').last) }
         .map { |ck| ck['source_url'] || ck ['external_url'] }
-        .last
+        .first
         .tap do |source|
           raise "Canot find any changelog source for #{name}" unless source
         end

--- a/lib/knife/changelog/version.rb
+++ b/lib/knife/changelog/version.rb
@@ -1,5 +1,5 @@
 module Knife
   module Changelog
-    VERSION = "0.5.14"
+    VERSION = "0.5.15"
   end
 end


### PR DESCRIPTION
Chef says the Berkshelf's source order define the preference.
Use the first supermarket source containing the cookbook to retrieve
its changelog.

**Cc.** @aboten