### PR TITLE
Fix URL matching regex for git repository

### DIFF
--- a/lib/knife/changelog/changelog.rb
+++ b/lib/knife/changelog/changelog.rb
@@ -130,7 +130,7 @@ class KnifeChangelog
       raise "No source found in supermarket for cookbook '#{name}'" unless url
       Chef::Log.debug("Using #{url} as source url")
       case url.strip
-      when /(gitlab.*|github).com\/(.*)(.git)?/
+      when /(gitlab.*|github).com\/([^.]+)(.git)?/
         url = "https://#{$1}.com/#{$2.chomp('/')}.git"
         options = {
           :git => url,


### PR DESCRIPTION
When handling a git repository URL referenced in a supermarket, the
source URL is matched against a regex to extract the revelant parts.

Unfortunately the '.git' suffix, if present, is not correctly stripped
but is always added later. This leads to a URL that can't be cloned.

This changes the regex to correctly strip the '.git' suffix.